### PR TITLE
Spin Correction + Absolute Mode Correction

### DIFF
--- a/scripts/scenes/LegacyRunner.cs
+++ b/scripts/scenes/LegacyRunner.cs
@@ -1368,7 +1368,7 @@ public partial class LegacyRunner : BaseScene
 				Camera.Rotation.X, Mathf.DegToRad(-90), Mathf.DegToRad(90)), Camera.Rotation.Y, Camera.Rotation.Z);
 
 			Camera.Position = new Vector3(0,0,3.5f) + new Vector3(
-				CurrentAttempt.CursorPosition.X * 0.25f, CurrentAttempt.CursorPosition.Y * 0.25f, 0
+				CurrentAttempt.CursorPosition.X, CurrentAttempt.CursorPosition.Y, 0
 			) * settings.CameraParallax + (Camera.Basis.Z / 4f);
 
 			Vector3 LookVector = Camera.Basis.Z;
@@ -1382,10 +1382,7 @@ public partial class LegacyRunner : BaseScene
 				LookVector.X, LookVector.Y
 			) * Mathf.Abs(Camera.Position.Z / LookVector.Z);
 
-			GD.Print(LookVector);
-
 			CurrentAttempt.RawCursorPosition = RawCursorPos;
-			// CurrentAttempt.RawCursorPosition = new Vector2(LookVector.X, LookVector.Y).Normalized() * -distance;
 			CurrentAttempt.CursorPosition = CurrentAttempt.RawCursorPosition.Clamp(-Constants.BOUNDS, Constants.BOUNDS);
 			cursor.Position = new Vector3(CurrentAttempt.CursorPosition.X, CurrentAttempt.CursorPosition.Y, 0);
 

--- a/scripts/scenes/LegacyRunner.cs
+++ b/scripts/scenes/LegacyRunner.cs
@@ -1353,7 +1353,8 @@ public partial class LegacyRunner : BaseScene
 		float sensitivity = (float)(CurrentAttempt.IsReplay ? CurrentAttempt.Replays[0].Sensitivity : settings.Sensitivity);
 		sensitivity *= (float)settings.FoV.Value / 70f;
 
-		if (settings.AbsoluteInput) {
+		if (settings.AbsoluteInput)
+		{
 			// Reset everything to zero so it doesn't spin endlessly, or have infinite sensitivity
 			Camera.Rotation = Vector3.Zero;
 			CurrentAttempt.RawCursorPosition = Vector2.Zero;

--- a/scripts/scenes/LegacyRunner.cs
+++ b/scripts/scenes/LegacyRunner.cs
@@ -1351,7 +1351,7 @@ public partial class LegacyRunner : BaseScene
 	public static void UpdateCursor(Vector2 mouseDelta)
 	{
 		float sensitivity = (float)(CurrentAttempt.IsReplay ? CurrentAttempt.Replays[0].Sensitivity : settings.Sensitivity);
-		// sensitivity *= (float)settings.FoV.Value / 70f;
+		sensitivity *= (float)settings.FoV.Value / 70f;
 
 		if (settings.AbsoluteInput) {
 			// Reset everything to zero so it doesn't spin endlessly, or have infinite sensitivity

--- a/scripts/scenes/LegacyRunner.cs
+++ b/scripts/scenes/LegacyRunner.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using Godot;
+using GodotPlugins.Game;
 
 public partial class LegacyRunner : BaseScene
 {
@@ -1363,14 +1364,28 @@ public partial class LegacyRunner : BaseScene
 		else
 		{
 			Camera.Rotation += new Vector3(-mouseDelta.Y / 120 * sensitivity / (float)Math.PI, -mouseDelta.X / 120 * sensitivity / (float)Math.PI, 0);
-			Camera.Rotation = new Vector3((float)Math.Clamp(Camera.Rotation.X, Mathf.DegToRad(-90), Mathf.DegToRad(90)), Camera.Rotation.Y, Camera.Rotation.Z);
-			Camera.Position = new Vector3(CurrentAttempt.CursorPosition.X * 0.25f, CurrentAttempt.CursorPosition.Y * 0.25f, 3.5f) + Camera.Basis.Z / 4;
+			Camera.Rotation = new Vector3((float)Math.Clamp(
+				Camera.Rotation.X, Mathf.DegToRad(-90), Mathf.DegToRad(90)), Camera.Rotation.Y, Camera.Rotation.Z);
 
-			float wtf = 0.95f;
-			float hypotenuse = (wtf + Camera.Position.Z) / Camera.Basis.Z.Z;
-			float distance = (float)Math.Sqrt(Math.Pow(hypotenuse, 2) - Math.Pow(wtf + Camera.Position.Z, 2));
+			Camera.Position = new Vector3(0,0,3.5f) + new Vector3(
+				CurrentAttempt.CursorPosition.X * 0.25f, CurrentAttempt.CursorPosition.Y * 0.25f, 0
+			) * settings.CameraParallax + (Camera.Basis.Z / 4f);
 
-			CurrentAttempt.RawCursorPosition = new Vector2(Camera.Basis.Z.X, Camera.Basis.Z.Y).Normalized() * -distance;
+			Vector3 LookVector = Camera.Basis.Z;
+			if (LookVector.Z == 0) return;
+
+			Vector2 RawCursorPos;
+
+			RawCursorPos = new Vector2(
+				Camera.Position.X, Camera.Position.Y
+			) - new Vector2(
+				LookVector.X, LookVector.Y
+			) * Mathf.Abs(Camera.Position.Z / LookVector.Z);
+
+			GD.Print(LookVector);
+
+			CurrentAttempt.RawCursorPosition = RawCursorPos;
+			// CurrentAttempt.RawCursorPosition = new Vector2(LookVector.X, LookVector.Y).Normalized() * -distance;
 			CurrentAttempt.CursorPosition = CurrentAttempt.RawCursorPosition.Clamp(-Constants.BOUNDS, Constants.BOUNDS);
 			cursor.Position = new Vector3(CurrentAttempt.CursorPosition.X, CurrentAttempt.CursorPosition.Y, 0);
 


### PR DESCRIPTION
Spin parallax is accurate to Sound Space (only if you set your parallax to 0.25)

Absolute Mode is as accurate to nightly as can get. Not tested on 2k or 4k monitors, so feedback on that would be appreciated! 1 sensitivity is as 1:1 as i can get to nightly absolute scale so the tablet players don't change it every 10 seconds to find their nightly sensitivity

Feedback appreciated! This is all just a temp bandaid until refactor (next tester build maybe? 👀)