### PR TITLE
Settings + Minor Changes

### DIFF
--- a/scripts/SettingsManager.cs
+++ b/scripts/SettingsManager.cs
@@ -11,6 +11,9 @@ using Godot.Collections;
 public partial class SettingsManager : Node
 {
     public static bool Shown = false;
+
+    public static bool HideNotifications = false;
+
     public static ColorRect Menu;
 
     public static SettingsManager Instance { get; private set; }
@@ -130,5 +133,29 @@ public partial class SettingsManager : Node
         }
 
         return "default";
+    }
+
+    // the HideNotifications bool exists to prevent a lot of toasts that inform the user of changing the skin to "default",
+    // this bool is only used inside of SkinManager - line 164.
+    public static void ResetToDefaults()
+    {
+        HideNotifications = true;
+
+        SettingsProfile defaults = new SettingsProfile();
+
+        foreach(var property in typeof(SettingsProfile).GetProperties())
+        {
+            if (!typeof(ISettingsItem).IsAssignableFrom(property.PropertyType)) continue;
+
+            ISettingsItem current = (ISettingsItem)property.GetValue(Instance.Settings);
+            ISettingsItem defs = (ISettingsItem)property.GetValue(defaults);
+
+            current.SetVariant(defs.GetVariant());
+        }
+
+        Save();
+        HideNotifications = false;
+
+        ToastNotification.Notify("Settings reset to default successfully!");
     }
 }

--- a/scripts/database/settings/SettingsProfile.cs
+++ b/scripts/database/settings/SettingsProfile.cs
@@ -258,15 +258,23 @@ public partial class SettingsProfile
 
     #region Other
 
-    [Order]
-    public SettingsItem<Variant> RhythiaImport { get; private set; }
+    // [Order]
+    /// <summary>
+    /// Import settings from previous (nightly) version
+    /// </summary>
+    // public SettingsItem<Variant> RhythiaImport { get; private set; }
 
+    [Order]
     /// <summary>
     /// Toggles recording for replays
     /// </summary>
-    [Order]
     public SettingsItem<bool> RecordReplays { get; private set; }
 
+    [Order]
+    /// <summary>
+    /// Restarts settings to the game's defaults
+    /// </summary>
+    public SettingsItem<Variant> ResetToDefaults { get; private set; }
     #endregion
 
     public SettingsProfile()
@@ -741,18 +749,18 @@ public partial class SettingsProfile
             }
         };
 
-        RhythiaImport = new(default)
-        {
-            Id = "RhythiaImport",
-            Title = "Import Nightly Settings",
-            Description = "Imports settings from the nightly client",
-            Section = SettingsSection.Other,
-            Buttons =
-            [
-                new() { Title = "Import", Description = "", OnPressed = () => { } }
-            ],
-            SaveToDisk = false,
-        };
+        // RhythiaImport = new(default)
+        // {
+        //     Id = "RhythiaImport",
+        //     Title = "Import Nightly Settings",
+        //     Description = "Imports settings from the nightly client",
+        //     Section = SettingsSection.Other,
+        //     Buttons =
+        //     [
+        //         new() { Title = "Import", Description = "", OnPressed = () => { } }
+        //     ],
+        //     SaveToDisk = false,
+        // };
 
         RecordReplays = new(true)
         {
@@ -760,6 +768,20 @@ public partial class SettingsProfile
             Title = "Record Replays",
             Description = "Toggles recording for replays",
             Section = SettingsSection.Other
+        };
+
+        ResetToDefaults = new(default)
+        {
+            Id = "ResetToDefaults",
+            Title = "Reset to Defaults",
+            Description = "Resets all settings to default values.",
+            Section = SettingsSection.Other,
+            Buttons = 
+            [
+                new() {Title = "Reset", Description = "WARNING: THIS RESETS YOUR CURRENT PROFILE!", OnPressed = () => {
+                    SettingsManager.ResetToDefaults();
+                }}
+            ],
         };
 
         #endregion

--- a/scripts/skinning/SkinManager.cs
+++ b/scripts/skinning/SkinManager.cs
@@ -161,7 +161,7 @@ public partial class SkinManager : Node
 		skin.MenuSpace = loadSpace($"res://prefabs/spaces/{(settings.MenuSpace.Value == "skin" ? skin.Config.MenuSpace : settings.MenuSpace.Value)}.tscn");
 
         /////
-
+		if (!SettingsManager.HideNotifications)
         ToastNotification.Notify($"Loaded skin [{settings.Skin.Value}]");
 		Logger.Log($"Loaded skin {settings.Skin.Value}");
 

--- a/scripts/ui/SettingsMenu.cs
+++ b/scripts/ui/SettingsMenu.cs
@@ -154,11 +154,17 @@ public partial class SettingsMenu : ColorRect
 
                 if (setting.Type == typeof(Variant))
                 {
-                //     Button button = buttonTemplate.Duplicate() as Button;
-
-                //     setupButton(setting, button);
-                //     panel.AddChild(button);
-                }
+                    var item = setting as SettingsItem<Variant>;
+                    if (item?.Buttons != null)
+                    {
+                        foreach (var settingButton in item.Buttons)
+                        {
+                            Button button = buttonTemplate.Duplicate() as Button;
+                            setupButton(settingButton, button);
+                            panel.AddChild(button);
+                        }
+                    }
+}               
 
                 container.AddChild(panel);
                 settingPanels[setting.Id] = panel;
@@ -374,8 +380,11 @@ public partial class SettingsMenu : ColorRect
         optionButton.Selected = index;
     }
 
-    // private void setupButton(ISettingsItem setting, Button button)
-    // {
-
-    // }
+    private void setupButton(SettingsButton setting, Button button)
+    {
+    button.Text = setting.Title;
+    button.TooltipText = setting.Description;
+    button.Visible = true;
+    button.Pressed += () => { setting.OnPressed?.Invoke(); };
+    }
 }


### PR DESCRIPTION
Kind of a bigger PR but, I'll briefly go over what I did

- Re-implemented SetupButton inside SettingsMenu back, and the support for settings of Variant type.

- Changed order of some elements, like [Order] blocks in SettingsProfile.cs, for a more consistent look (doesn't affect code.)

- Hid the "Import from Nightly" setting as it is a placeholder.

- Added a setting that lets you restart your current profile to default values.

^ it's a very wacky implementation but it works. we essentially replace every value in the users current profile to the values we fetch from a new SettingsProfile. if anyone has a better approach for this - let me know.