### PR TITLE
Add support for other image file types other than .png

### DIFF
--- a/scripts/map/Map.cs
+++ b/scripts/map/Map.cs
@@ -92,34 +92,21 @@ public partial class Map : RefCounted
             return [];
         }
     }
-
+    
     private Texture2D getCover()
     {
-        byte[] pngSignature = { 137, 80, 78, 71, 13, 10, 26, 10 };
-
         string path = $"{MapUtil.MapsCacheFolder}/{Name}";
 
         if (cover == DefaultCover && File.Exists($"{path}/cover.png"))
-        {
-            byte[] coverBuffer = File.ReadAllBytes($"{path}/cover.png");
-
-            Image image = new Image();
-
-            if (coverBuffer.Take(8).SequenceEqual(pngSignature))
-            {
-                image.LoadPngFromBuffer(coverBuffer);
-            }
-            else
-            {
-                image.LoadJpgFromBuffer(coverBuffer);
-            }
-
+    {
+        byte[] coverBuffer = File.ReadAllBytes($"{path}/cover.png");
+        Image image = Util.Misc.LoadImageFromBuffer(coverBuffer);
+        if (image != null)
             cover = ImageTexture.CreateFromImage(image);
         }
 
-        return cover;
-    }
-
+    return cover;
+}
     public Map() { }
 
     public Map(string filePath, Note[] data = null, string id = null, string artist = "", string title = "", float rating = 0, string[] mappers = null, int difficulty = 0, string difficultyName = null, int? length = null, byte[] audioBuffer = null, byte[] coverBuffer = null, byte[] videoBuffer = null, bool ephemeral = false, string artistLink = "", string artistPlatform = "")

--- a/scripts/map/MapCache.cs
+++ b/scripts/map/MapCache.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Godot;
+using Util;
 
 public static class MapCache
 {
@@ -246,8 +247,6 @@ public static class MapCache
         //TODO: not make this terrible
         Task.Run(() =>
         {
-            byte[] pngSignature = { 137, 80, 78, 71, 13, 10, 26, 10 };
-
             foreach (var map in maps)
             {
                 string path = $"{MapUtil.MapsCacheFolder}/{map.Name}";
@@ -255,19 +254,14 @@ public static class MapCache
                 if (map.Cover == Map.DefaultCover && File.Exists($"{path}/cover.png"))
                 {
                     byte[] coverBuffer = File.ReadAllBytes($"{path}/cover.png");
+                    Image image = Util.Misc.LoadImageFromBuffer(coverBuffer);
 
-                    Image image = new Image();
-
-                    if (coverBuffer.Take(8).SequenceEqual(pngSignature))
-                    {
-                        image.LoadPngFromBuffer(coverBuffer);
+                    if (image != null){
+                        Callable.From(() => {
+                            map.Cover = ImageTexture.CreateFromImage(image);
+                            }).CallDeferred();
                     }
-                    else
-                    {
-                        image.LoadJpgFromBuffer(coverBuffer);
-                    }
-
-                    map.Cover = ImageTexture.CreateFromImage(image);
+                    
                 }
             }
         });

--- a/scripts/map/MapParser.cs
+++ b/scripts/map/MapParser.cs
@@ -608,7 +608,7 @@ public partial class MapParser : Node
                 stream.CopyTo(memoryStream);
                 stream.Dispose();
 
-                byte[] buffer = memoryStream.GetBuffer();
+                byte[] buffer = memoryStream.ToArray();
                 memoryStream.Dispose();
 
                 return buffer;

--- a/scripts/map/MapUtil.cs
+++ b/scripts/map/MapUtil.cs
@@ -1,7 +1,7 @@
 ﻿internal static class MapUtil
 {
-
     public static string MapsFolder => $"{Constants.USER_FOLDER}/maps";
 
     public static string MapsCacheFolder => $"{Constants.USER_FOLDER}/cache/maps";
+
 }

--- a/scripts/scenes/Results.cs
+++ b/scripts/scenes/Results.cs
@@ -5,21 +5,6 @@ using System.IO;
 
 public partial class Results : BaseScene
 {
-	private static Image LoadImageFromBuffer(byte[] buffer)
-{
-    Image img = new Image();
-    foreach (var load in new Func<byte[], Error>[] {
-        img.LoadPngFromBuffer,
-        img.LoadJpgFromBuffer,
-        img.LoadWebpFromBuffer,
-        img.LoadBmpFromBuffer,
-    })
-    {
-        if (load(buffer) == Error.Ok)
-            return img;
-    }
-    return null;
-}
 	private SettingsProfile settings;
 
 	private static Panel footer;
@@ -69,7 +54,7 @@ public partial class Results : BaseScene
 
 		if (LegacyRunner.CurrentAttempt.Map.CoverBuffer != null)
 		{
-		    Image img = LoadImageFromBuffer(LegacyRunner.CurrentAttempt.Map.CoverBuffer);
+		    Image img = Util.Misc.LoadImageFromBuffer(LegacyRunner.CurrentAttempt.Map.CoverBuffer);
 		    if (img != null)
 		    {
 		        cover.Texture = ImageTexture.CreateFromImage(img);

--- a/scripts/scenes/Results.cs
+++ b/scripts/scenes/Results.cs
@@ -5,6 +5,21 @@ using System.IO;
 
 public partial class Results : BaseScene
 {
+	private static Image LoadImageFromBuffer(byte[] buffer)
+{
+    Image img = new Image();
+    foreach (var load in new Func<byte[], Error>[] {
+        img.LoadPngFromBuffer,
+        img.LoadJpgFromBuffer,
+        img.LoadWebpFromBuffer,
+        img.LoadBmpFromBuffer,
+    })
+    {
+        if (load(buffer) == Error.Ok)
+            return img;
+    }
+    return null;
+}
 	private SettingsProfile settings;
 
 	private static Panel footer;
@@ -54,12 +69,12 @@ public partial class Results : BaseScene
 
 		if (LegacyRunner.CurrentAttempt.Map.CoverBuffer != null)
 		{
-			Godot.FileAccess file = Godot.FileAccess.Open($"{Constants.USER_FOLDER}/cache/cover.png", Godot.FileAccess.ModeFlags.Write);
-			file.StoreBuffer(LegacyRunner.CurrentAttempt.Map.CoverBuffer);
-			file.Close();
-
-			cover.Texture = ImageTexture.CreateFromImage(Image.LoadFromFile($"{Constants.USER_FOLDER}/cache/cover.png"));
-			GetNode<TextureRect>("CoverBackground").Texture = cover.Texture;
+		    Image img = LoadImageFromBuffer(LegacyRunner.CurrentAttempt.Map.CoverBuffer);
+		    if (img != null)
+		    {
+		        cover.Texture = ImageTexture.CreateFromImage(img);
+		        GetNode<TextureRect>("CoverBackground").Texture = cover.Texture;
+		    }
 		}
 
 		if (LegacyRunner.CurrentAttempt.Map.AudioBuffer != null)

--- a/scripts/util/Misc.cs
+++ b/scripts/util/Misc.cs
@@ -51,4 +51,20 @@ public class Misc
         reference.ReplaceBy(node);
         reference.QueueFree();
     }
+
+public static Image LoadImageFromBuffer(byte[] buffer)
+    {
+        Image img = new Image();
+        foreach (var load in new Func<byte[], Error>[] {
+            img.LoadPngFromBuffer,
+            img.LoadJpgFromBuffer,
+            img.LoadWebpFromBuffer,
+            img.LoadBmpFromBuffer,
+        })
+        {
+            if (load(buffer) == Error.Ok)
+                return img;
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
People tend to do some questionable things like renaming their .jpg files to .png, and then opening support threads in the Discord to ask why their background doesn't work.
This PR on top of PNG support adds JPG, WEBP and BMP support. I've only included the most relevant file types from https://docs.godotengine.org/en/stable/tutorials/assets_pipeline/importing_images.html.
Another thought was that we COULD automatically make the users image a .png if it already wasn't one but I think this works equally as good, atleast for now.
