### PR TITLE
fix(stats): save stats on attempt and populate stats UI

### DIFF
--- a/scripts/database/Stats.cs
+++ b/scripts/database/Stats.cs
@@ -7,6 +7,8 @@ using Godot.Collections;
 [GlobalClass]
 public partial class Stats : Node
 {
+    public static event Action OnSaved;
+
     public static ulong GamePlaytime = 0;
     public static ulong TotalPlaytime = 0;
     public static ulong GamesOpened = 0;
@@ -61,6 +63,8 @@ public partial class Stats : Node
         file.Close();
 
         File.SetAttributes($"{Constants.USER_FOLDER}/stats", FileAttributes.Hidden);
+
+        OnSaved?.Invoke();
         Logger.Log("Saved stats");
     }
 

--- a/scripts/scenes/LegacyRunner.cs
+++ b/scripts/scenes/LegacyRunner.cs
@@ -1488,6 +1488,8 @@ public partial class LegacyRunner : BaseScene
                     Stats.PassAccuracies.Add(CurrentAttempt.Accuracy);
                 }
             }
+
+            Stats.Save();
         }
 
         if (results)

--- a/scripts/ui/menu/extras/StatsPanel.cs
+++ b/scripts/ui/menu/extras/StatsPanel.cs
@@ -6,7 +6,14 @@ public partial class StatsPanel : ExtrasPanel
     public override void _Ready()
     {
         base._Ready();
+        Stats.OnSaved += Update;
         Update();
+    }
+
+    public override void _ExitTree()
+    {
+        base._ExitTree();
+        Stats.OnSaved -= Update;
     }
 
     // populates all stat labels from the Stats class

--- a/scripts/ui/menu/extras/StatsPanel.cs
+++ b/scripts/ui/menu/extras/StatsPanel.cs
@@ -1,17 +1,40 @@
-using System;
 using Godot;
+using System.Linq;
 
 public partial class StatsPanel : ExtrasPanel
 {
     public override void _Ready()
     {
         base._Ready();
-
         Update();
     }
 
+    // populates all stat labels from the Stats class
     public void Update()
     {
+        var vbox = GetNode<VBoxContainer>("ScrollContainer/VBoxContainer");
 
+        // playtime is stored in seconds, convert to hours
+        vbox.GetNode<Label>("GamePlaytime/Value").Text = $"{Stats.GamePlaytime / 3600}h";
+        vbox.GetNode<Label>("TotalPlaytime/Value").Text = $"{Stats.TotalPlaytime / 3600}h";
+        vbox.GetNode<Label>("GamesOpened/Value").Text = $"{Stats.GamesOpened}";
+
+        // distance stored in milimeters, convert to meters
+        vbox.GetNode<Label>("TotalDistance/Value").Text = $"{Stats.TotalDistance / 1000}m";
+        vbox.GetNode<Label>("NotesHit/Value").Text = $"{Stats.NotesHit}";
+        vbox.GetNode<Label>("NotesMissed/Value").Text = $"{Stats.NotesMissed}";
+        vbox.GetNode<Label>("HighestCombo/Value").Text = $"{Stats.HighestCombo}";
+        vbox.GetNode<Label>("Attempts/Value").Text = $"{Stats.Attempts}";
+        vbox.GetNode<Label>("Passes/Value").Text = $"{Stats.Passes}";
+        vbox.GetNode<Label>("FullCombos/Value").Text = $"{Stats.FullCombos}";
+        vbox.GetNode<Label>("HighestScore/Value").Text = $"{Stats.HighestScore}";
+        vbox.GetNode<Label>("TotalScore/Value").Text = $"{Stats.TotalScore}";
+        vbox.GetNode<Label>("AverageAccuracy/Value").Text = Stats.PassAccuracies.Count > 0
+            ? $"{Stats.PassAccuracies.ToArray().Average().ToString().PadDecimals(2)}%"
+            : "0%";
+        vbox.GetNode<Label>("RageQuits/Value").Text = $"{Stats.RageQuits}";
+        vbox.GetNode<Label>("FavouriteMap/Value").Text = Stats.FavoriteMaps.Count > 0
+            ? Stats.FavoriteMaps.ToArray().OrderByDescending(x => x.Value).First().Key
+            : "";
     }
 }


### PR DESCRIPTION
this addresses issue #43 

Stats.Save() was never called after updating stats in LegacyRunner.Stop(), so it only stayed in memory.
StatsPanel.Update() was empty, so the stats panel never displayed any values