### PR TITLE
fix: half-size notes on first launch or mesh change

### DIFF
--- a/scripts/skinning/SkinManager.cs
+++ b/scripts/skinning/SkinManager.cs
@@ -222,7 +222,7 @@ public partial class SkinManager : Node
     {
         bool exists = ResourceLoader.Exists(path) || Godot.FileAccess.FileExists(path);
 
-        return exists ? (ArrayMesh)Util.Misc.OBJParser.Call("load_obj", path) : GD.Load<ArrayMesh>($"res://user/meshes/squircle.obj");
+        return Util.Misc.OBJParser.Call("load_obj", exists ? path : "res://user/meshes/squircle.obj").As<ArrayMesh>();
     }
 
     private static BaseSpace loadSpace(string path)


### PR DESCRIPTION
fixes notes being half-size on first launch or note mesh change by changing the fallback to use objparser