### PR TITLE
fix: non-embedded subwindows crash

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -52,7 +52,6 @@ file_logging/enable_file_logging=true
 
 window/size/viewport_width=1280
 window/size/viewport_height=720
-window/subwindows/embed_subwindows=false
 
 [dotnet]
 


### PR DESCRIPTION
had to disable a super duper omega hidden setting in the tombs of godot project settings

previously caused crashes on certain devices lacking permission to create new windows