### PR TITLE
Fix: Force left-right node layout direction

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -75,6 +75,10 @@ timers/tooltip_delay_sec=0.1
 
 pointing/android/enable_long_press_as_right_click=true
 
+[internationalization]
+
+rendering/root_node_layout_direction=1
+
 [physics]
 
 common/physics_ticks_per_second=120


### PR DESCRIPTION
Fixes the whole UI being mirrored on right-to-left locale