### PR TITLE
Feat: Note opacity exponent setting

### DIFF
--- a/scripts/database/settings/SettingsProfile.cs
+++ b/scripts/database/settings/SettingsProfile.cs
@@ -126,6 +126,12 @@ public partial class SettingsProfile
     public SettingsItem<double> NoteOpacity { get; private set; }
 
     /// <summary>
+    /// Adjusts the note opacity curve, a higher value will make any sort of transparency appear more quickly
+    /// </summary>
+    [Order]
+    public SettingsItem<double> NoteOpacityExponent { get; private set; }
+
+    /// <summary>
     /// Overrides the skin's note mesh
     /// </summary>
     [Order]
@@ -586,6 +592,20 @@ public partial class SettingsProfile
                 Step = 0.05f,
                 MinValue = 0,
                 MaxValue = 1
+            }
+        };
+
+        NoteOpacityExponent = new(1.25)
+        {
+            Id = "NoteOpacityExponent",
+            Title = "Note Opacity Exponent",
+            Description = "Adjusts the note opacity curve, a higher value will make any sort of transparency appear more quickly",
+            Section = SettingsSection.Visual,
+            Slider = new()
+            {
+                Step = 0.05f,
+                MinValue = 1,
+                MaxValue = 2
             }
         };
 

--- a/scripts/game/LegacyRenderer.cs
+++ b/scripts/game/LegacyRenderer.cs
@@ -32,6 +32,7 @@ public partial class LegacyRenderer : MultiMeshInstance3D
         bool pushback = LegacyRunner.CurrentAttempt.IsReplay ? LegacyRunner.CurrentAttempt.Replays[0].Pushback : settings.Pushback.Value;
         float hitWindowDepth = pushback ? (float)Constants.HIT_WINDOW * ar / 1000 : 0;
         float noteOpacity = (float)settings.NoteOpacity;
+        float noteOpacityExponent = (float)settings.NoteOpacityExponent;
 
         if (noteOpacity > 1)
         {
@@ -74,7 +75,7 @@ public partial class LegacyRenderer : MultiMeshInstance3D
             Color color = SkinManager.Instance.Skin.NoteColors[note.Index % SkinManager.Instance.Skin.NoteColors.Length];
 
             transform.Origin = new Vector3(note.X, note.Y, -depth);
-            color.A = Math.Clamp(alpha * noteOpacity, 0, 1);
+            color.A = Math.Clamp((float)Math.Pow(alpha * noteOpacity, noteOpacityExponent), 0, 1);
             Multimesh.SetInstanceTransform(j, transform);
             Multimesh.SetInstanceColor(j, color);
         }


### PR DESCRIPTION
defaults to 1.25 (old behaves like 1), allows transparency to set in more quickly and can make opacity behaviour more similar to nightly