### PR TITLE
Fix: Sanitize BBCode and zalgo/diacritics from map metadata

### DIFF
--- a/prefabs/map_info_container.tscn
+++ b/prefabs/map_info_container.tscn
@@ -176,7 +176,7 @@ outline_color = Color(0, 0, 0, 1)
 shadow_size = 4
 shadow_color = Color(0, 0, 0, 1)
 
-[node name="MapInfoContainer" type="Panel" unique_id=150923669]
+[node name="MapInfoContainer" type="Panel" unique_id=150923669 node_paths=PackedStringArray("info", "dim", "coverBackground", "cover", "infoSubholder", "mainLabel", "extraLabel", "artistLink", "favoriteButton", "videoButton", "videoDialog", "copyButton", "copyDialog", "deleteButton", "actions", "preview", "speedHolder", "speedPresets", "playHolder", "startButton", "leaderboard", "lbScrollContainer", "lbContainer", "lbExpand", "lbHide")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -186,6 +186,31 @@ grow_vertical = 2
 mouse_filter = 2
 theme_override_styles/panel = SubResource("StyleBoxEmpty_svokg")
 script = ExtResource("1_50xtp")
+info = NodePath("Info")
+dim = NodePath("Dim")
+coverBackground = NodePath("Info/ScrollContainer/Holder/CoverContainer/Background")
+cover = NodePath("Info/ScrollContainer/Holder/CoverContainer/Background/Cover")
+infoSubholder = NodePath("Info/ScrollContainer/Holder")
+mainLabel = NodePath("Info/ScrollContainer/Holder/Subholder/Main")
+extraLabel = NodePath("Info/ScrollContainer/Holder/Subholder/Extra")
+artistLink = NodePath("Info/ScrollContainer/Holder/CoverContainer/Background/ArtistLink")
+favoriteButton = NodePath("Info/ScrollContainer/Holder/Subholder/Buttons/Favorite")
+videoButton = NodePath("Info/ScrollContainer/Holder/Subholder/Buttons/Video")
+videoDialog = NodePath("Info/ScrollContainer/Holder/Subholder/Buttons/Video/VideoDialog")
+copyButton = NodePath("Info/ScrollContainer/Holder/Subholder/Buttons/Copy")
+copyDialog = NodePath("Info/ScrollContainer/Holder/Subholder/Buttons/Copy/CopyDialog")
+deleteButton = NodePath("Info/ScrollContainer/Holder/Subholder/Buttons/Delete")
+actions = NodePath("Actions")
+preview = NodePath("Actions/ScrollContainer/Holder/Preview/AspectRatioContainer/FlatPreview")
+speedHolder = NodePath("Actions/ScrollContainer/Holder/Speed")
+speedPresets = NodePath("Actions/ScrollContainer/Holder/Speed/ScrollContainer/Presets")
+playHolder = NodePath("Actions/ScrollContainer/Holder/Play")
+startButton = NodePath("Actions/ScrollContainer/Holder/Play/Button")
+leaderboard = NodePath("Leaderboard")
+lbScrollContainer = NodePath("Leaderboard/ScrollContainer")
+lbContainer = NodePath("Leaderboard/ScrollContainer/VBoxContainer")
+lbExpand = NodePath("Leaderboard/Expand")
+lbHide = NodePath("LeaderboardHide")
 
 [node name="Info" type="Panel" parent="." unique_id=1638277412]
 layout_mode = 1
@@ -314,7 +339,7 @@ text = "[color=ffffff88]{0}
 horizontal_alignment = 2
 vertical_alignment = 2
 
-[node name="MainLabel" type="RichTextLabel" parent="Info/ScrollContainer/Holder/Subholder" unique_id=394044659]
+[node name="Main" type="RichTextLabel" parent="Info/ScrollContainer/Holder/Subholder" unique_id=394044659]
 layout_mode = 1
 anchors_preset = -1
 anchor_right = 1.0

--- a/scripts/map/Map.cs
+++ b/scripts/map/Map.cs
@@ -122,24 +122,19 @@ public partial class Map : RefCounted
         PrettyTitle = Artist != "" ? $"{Artist} - {Title}" : Title;
         Rating = rating;
         Mappers = mappers ?? ["N/A"];
+        PrettyMappers = mappers.Join();
         CachedMappers = mappers.Join("_");
-        PrettyMappers = "";
-        Difficulty = difficulty;
+        Difficulty = Math.Clamp(difficulty, 0, Constants.DIFFICULTIES.Length - 1);
         DifficultyName = difficultyName?.StripEscapes() ?? Constants.DIFFICULTIES[Difficulty];
         AudioBuffer = audioBuffer;
         CoverBuffer = coverBuffer;
         VideoBuffer = videoBuffer;
         Notes = data ?? Array.Empty<Note>();
         Length = length ?? Notes[^1].Millisecond;
-        Name = (id.Replace(" ", "_") ?? new Regex("[^a-zA-Z0-9_-]").Replace($"{Mappers.Stringify()}_{PrettyTitle}".Replace(" ", "_"), ""));
+        Name = id.Replace(" ", "_") ?? new Regex("[^a-zA-Z0-9_-]").Replace($"{Mappers.Stringify()}_{PrettyTitle}".Replace(" ", "_"), "");
         AudioExt = (AudioBuffer != null && Encoding.UTF8.GetString(AudioBuffer[0..4]) == "OggS") ? "ogg" : "mp3";
 
-        foreach (string mapper in Mappers)
-        {
-            PrettyMappers += $"{mapper}, ";
-        }
-
-        PrettyMappers = PrettyMappers.Substr(0, PrettyMappers.Length - 2).StripEscapes();
+        MapManager.Sanitize(this);
     }
 
     public string EncodeMeta()

--- a/scripts/map/MapCache.cs
+++ b/scripts/map/MapCache.cs
@@ -178,6 +178,7 @@ public static class MapCache
     {
         var existing = DatabaseService.Connection.Find<Map>(x => x.Hash == x.Hash);
         var updated = DatabaseService.Connection.Find<Map>(x => x.Name == map.Name);
+        
         try
         {
             if (updated != null && existing != null)
@@ -276,13 +277,18 @@ public static class MapCache
 
         if (maps.Count < 1)
         {
-            MapManager.Maps = new();
+            MapManager.Maps = [];
             return;
         }
 
         var sortedMaps = maps.Where(x => x.Favorite).OrderBy(x => x.PrettyTitle).ToList();
 
         sortedMaps.AddRange(maps.Where(x => !x.Favorite).OrderBy(x => x.PrettyTitle));
+
+        foreach (var map in sortedMaps)
+        {
+            MapManager.Sanitize(map);
+        }
 
         MapManager.Maps = sortedMaps;
     }

--- a/scripts/map/MapCache.cs
+++ b/scripts/map/MapCache.cs
@@ -178,7 +178,7 @@ public static class MapCache
     {
         var existing = DatabaseService.Connection.Find<Map>(x => x.Hash == x.Hash);
         var updated = DatabaseService.Connection.Find<Map>(x => x.Name == map.Name);
-        
+
         try
         {
             if (updated != null && existing != null)

--- a/scripts/map/MapManager.cs
+++ b/scripts/map/MapManager.cs
@@ -1,10 +1,7 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Godot;
 
@@ -81,6 +78,7 @@ public partial class MapManager : Node
         map.VideoBuffer = null;
 
         var oldmap = MapParser.Decode(map.FilePath);
+        
         map.Mappers = map.PrettyMappers.Split(" ");
         map.AudioBuffer = oldmap.AudioBuffer;
         map.CoverBuffer = oldmap.CoverBuffer;
@@ -112,7 +110,6 @@ public partial class MapManager : Node
             MapCache.RemoveMap(map);
             Maps.RemoveAll(x => x.Id == map.Id);
 
-
             Callable.From(() =>
             {
                 _ = ToastNotification.Notify($"Deleted {map.PrettyTitle}!");
@@ -122,6 +119,25 @@ public partial class MapManager : Node
         catch (Exception e)
         {
             Logger.Error(e.Message);
+        }
+    }
+
+    public static void Sanitize(Map map)
+    {
+        string sanitizedTitle = Util.String.SanitizeZalgo(map.PrettyTitle);
+        string sanitizedMappers = Util.String.SanitizeZalgo(map.PrettyMappers);
+        string sanitizedDiffName = Util.String.SanitizeZalgo(map.DifficultyName);
+
+        bool updated = sanitizedTitle != map.PrettyTitle || sanitizedMappers != map.PrettyMappers || sanitizedDiffName != map.DifficultyName;
+
+        if (updated)
+        {
+            map.PrettyTitle = sanitizedTitle;
+            map.PrettyMappers = sanitizedMappers;
+            map.DifficultyName = sanitizedDiffName;
+
+            Update(map);
+            Logger.Log($"Sanitized map {map.Name}");
         }
     }
 

--- a/scripts/map/MapManager.cs
+++ b/scripts/map/MapManager.cs
@@ -78,7 +78,7 @@ public partial class MapManager : Node
         map.VideoBuffer = null;
 
         var oldmap = MapParser.Decode(map.FilePath);
-        
+
         map.Mappers = map.PrettyMappers.Split(" ");
         map.AudioBuffer = oldmap.AudioBuffer;
         map.CoverBuffer = oldmap.CoverBuffer;

--- a/scripts/ui/menu/play/MapButtonWide.cs
+++ b/scripts/ui/menu/play/MapButtonWide.cs
@@ -45,8 +45,8 @@ public partial class MapButtonWide : MapButton
         extra.Text = string.Format("[outline_size=2][outline_color=000000][color=808080]{0} — [color={1}]{2} [color=808080]by [color=b0b0b0]{3}",
             Util.String.FormatTime(map.Length / 1000),
             Constants.DIFFICULTY_COLORS[map.Difficulty].ToHtml(),
-            map.DifficultyName,
-            map.PrettyMappers
+            Util.String.SanitizeBBCode(map.DifficultyName),
+            Util.String.SanitizeBBCode(map.PrettyMappers)
         );
 
         stickoutOffset = selected ? 0.05f : 0;

--- a/scripts/ui/menu/play/MapInfoContainer.cs
+++ b/scripts/ui/menu/play/MapInfoContainer.cs
@@ -12,65 +12,116 @@ public partial class MapInfoContainer : Panel, ISkinnable
     public Leaderboard Leaderboard = new();
 
     private readonly PackedScene leaderboardScoreTemplate = ResourceLoader.Load<PackedScene>("res://prefabs/score_panel.tscn");
+    
+    // Info & main buttons
 
+    [ExportCategory("Info")]
+
+    [Export]
     private Panel info;
+
+    [Export]
+    private ColorRect dim;
+
+    [Export]
     private TextureRect coverBackground;
+
+    [Export]
     private TextureRect cover;
+
+    [Export]
     private Panel infoSubholder;
+
+    [Export]
     private RichTextLabel mainLabel;
     private string mainLabelFormat;
+
+    [Export]
     private RichTextLabel extraLabel;
     private string extraLabelFormat;
+
+    [Export]
     private LinkPopupButton artistLink;
     private string artistLinkFormat;
-    private HBoxContainer mapButtonsContainer;
+
+    [Export]
     private Button favoriteButton;
+
+    [Export]
     private Button videoButton;
+
+    [Export]
     private FileDialog videoDialog;
+
+    [Export]
     private Button copyButton;
+
+    [Export]
     private FileDialog copyDialog;
+
+    [Export]
     private Button deleteButton;
 
+    // Actions panel
+
+    [ExportCategory("Actions")]
+
+    [Export]
     private Panel actions;
-    private Panel previewHolder;
-    private Panel modesHolder;
-    private Panel modifiersHolder;
+
+    [Export]
+    private FlatPreview preview;
+
+    // [Export]
+    // private Panel previewHolder;
+
+    // [Export]
+    // private Panel modesHolder;
+
+    // [Export]
+    // private Panel modifiersHolder;
+
+    [Export]
     private Panel speedHolder;
+
+    [Export]
     private HBoxContainer speedPresets;
+
+    [Export]
     private Panel playHolder;
+
+    [Export]
     private Button startButton;
 
+    // Leaderboard
+
+    [ExportCategory("Leaderboards")]
+
+    [Export]
     private Panel leaderboard;
+
+    [Export]
     private ScrollContainer lbScrollContainer;
+
+    [Export]
     private VBoxContainer lbContainer;
+
+    [Export]
     private Button lbExpand;
+
+    [Export]
     private Button lbHide;
 
-    private ColorRect dim;
+    // Misc
+
     private ShaderMaterial outlineMaterial;
 
     public override void _Ready()
     {
-        info = GetNode<Panel>("Info");
-
-        Panel infoHolder = info.GetNode("ScrollContainer").GetNode<Panel>("Holder");
-
-        coverBackground = infoHolder.GetNode("CoverContainer").GetNode<TextureRect>("Background");
-        cover = coverBackground.GetNode<TextureRect>("Cover");
-        infoSubholder = infoHolder.GetNode<Panel>("Subholder");
-        mainLabel = infoSubholder.GetNode<RichTextLabel>("MainLabel");
         mainLabelFormat = mainLabel.Text;
-        extraLabel = infoSubholder.GetNode<RichTextLabel>("Extra");
         extraLabelFormat = extraLabel.Text;
-        artistLink = coverBackground.GetNode<LinkPopupButton>("ArtistLink");
         artistLinkFormat = artistLink.Text;
-        mapButtonsContainer = infoSubholder.GetNode<HBoxContainer>("Buttons");
-        favoriteButton = mapButtonsContainer.GetNode<Button>("Favorite");
-        videoButton = mapButtonsContainer.GetNode<Button>("Video");
-        videoDialog = videoButton.GetNode<FileDialog>("VideoDialog");
-        copyButton = mapButtonsContainer.GetNode<Button>("Copy");
-        copyDialog = copyButton.GetNode<FileDialog>("CopyDialog");
-        deleteButton = mapButtonsContainer.GetNode<Button>("Delete");
+        outlineMaterial = info.GetNode<Panel>("Outline").Material as ShaderMaterial;
 
         favoriteButton.Pressed += () =>
         {
@@ -114,33 +165,12 @@ public partial class MapInfoContainer : Panel, ISkinnable
 
         coverBackground.Connect("resized", Callable.From(updateOffset));
 
-        actions = GetNode<Panel>("Actions");
-
-        Panel actionsHolder = actions.GetNode("ScrollContainer").GetNode<Panel>("Holder");
-
-        previewHolder = actionsHolder.GetNode<Panel>("Preview");
-        modesHolder = actionsHolder.GetNode<Panel>("Modes");
-        modifiersHolder = actionsHolder.GetNode<Panel>("Modifiers");
-        speedHolder = actionsHolder.GetNode<Panel>("Speed");
-        speedPresets = speedHolder.GetNode("ScrollContainer").GetNode<HBoxContainer>("Presets");
-        playHolder = actionsHolder.GetNode<Panel>("Play");
-        startButton = playHolder.GetNode<Button>("Button");
-
-        leaderboard = GetNode<Panel>("Leaderboard");
-        lbScrollContainer = leaderboard.GetNode<ScrollContainer>("ScrollContainer");
-        lbContainer = lbScrollContainer.GetNode<VBoxContainer>("VBoxContainer");
-        lbExpand = leaderboard.GetNode<Button>("Expand");
-        lbHide = GetNode<Button>("LeaderboardHide");
-
-        dim = GetNode<ColorRect>("Dim");
-        outlineMaterial = info.GetNode<Panel>("Outline").Material as ShaderMaterial;
-
         Modulate = Color.Color8(255, 255, 255, 0);
 
         // Speed setup
 
-        HSlider speedSlider = speedHolder.GetNode<HSlider>("HSlider");
-        LineEdit speedEdit = speedHolder.GetNode<LineEdit>("LineEdit");
+        var speedSlider = speedHolder.GetNode<HSlider>("HSlider");
+        var speedEdit = speedHolder.GetNode<LineEdit>("LineEdit");
 
         void displaySpeed(double speed)
         {
@@ -190,8 +220,8 @@ public partial class MapInfoContainer : Panel, ISkinnable
 
         // StartFrom setup
 
-        HSlider startFromSlider = playHolder.GetNode<HSlider>("HSlider");
-        LineEdit startFromEdit = playHolder.GetNode<LineEdit>("LineEdit");
+        var startFromSlider = playHolder.GetNode<HSlider>("HSlider");
+        var startFromEdit = playHolder.GetNode<LineEdit>("LineEdit");
 
         void displayStartFrom(double startFrom)
         {
@@ -265,7 +295,7 @@ public partial class MapInfoContainer : Panel, ISkinnable
 
         // Leaderboard
 
-        Panel lbExpandHover = lbExpand.GetNode<Panel>("Hover");
+        var lbExpandHover = lbExpand.GetNode<Panel>("Hover");
 
         void tweenExpandHover(bool show)
         {
@@ -365,7 +395,7 @@ public partial class MapInfoContainer : Panel, ISkinnable
 
         Lobby.SetStartFrom(0);
 
-        previewHolder.GetNode("AspectRatioContainer").GetNode<FlatPreview>("FlatPreview").Setup(map, true);
+        preview.Setup(map, true);
 
         // Leaderboard
 

--- a/scripts/ui/menu/play/MapInfoContainer.cs
+++ b/scripts/ui/menu/play/MapInfoContainer.cs
@@ -12,7 +12,7 @@ public partial class MapInfoContainer : Panel, ISkinnable
     public Leaderboard Leaderboard = new();
 
     private readonly PackedScene leaderboardScoreTemplate = ResourceLoader.Load<PackedScene>("res://prefabs/score_panel.tscn");
-    
+
     // Info & main buttons
 
     [ExportCategory("Info")]

--- a/scripts/ui/menu/play/MapInfoContainer.cs
+++ b/scripts/ui/menu/play/MapInfoContainer.cs
@@ -378,10 +378,24 @@ public partial class MapInfoContainer : Panel, ISkinnable
 
         // Info
 
-        int clampedDifficulty = Math.Clamp(map.Difficulty, 0, Constants.DIFFICULTY_COLORS.Length - 1);
-        mainLabel.Text = string.Format(mainLabelFormat, map.PrettyTitle, Constants.DIFFICULTY_COLORS[clampedDifficulty].ToHtml(), map.DifficultyName, map.PrettyMappers);
-        extraLabel.Text = string.Format(extraLabelFormat, Util.String.FormatTime(map.Length / 1000), map.Notes.Length, map.Name);
-        coverBackground.SelfModulate = Constants.DIFFICULTY_COLORS[clampedDifficulty];
+        var difficultyColor = Constants.DIFFICULTY_COLORS[Math.Clamp(map.Difficulty, 0, Constants.DIFFICULTY_COLORS.Length - 1)];
+
+        mainLabel.Text = string.Format(
+            mainLabelFormat,
+            Util.String.SanitizeBBCode(map.PrettyTitle),
+            difficultyColor.ToHtml(),
+            Util.String.SanitizeBBCode(map.DifficultyName),
+            Util.String.SanitizeBBCode(map.PrettyMappers)
+        );
+
+        extraLabel.Text = string.Format(
+            extraLabelFormat,
+            Util.String.FormatTime(map.Length / 1000),
+            map.Notes.Length,
+            Util.String.SanitizeBBCode(map.Name)
+        );
+
+        coverBackground.SelfModulate = difficultyColor;
         cover.Texture = map.Cover;
         favoriteButton.TooltipText = map.Favorite ? "Unfavorite" : "Favorite";
         favoriteButton.Icon = map.Favorite ? SkinManager.Instance.Skin.UnfavoriteButtonImage : SkinManager.Instance.Skin.FavoriteButtonImage;

--- a/scripts/util/String.cs
+++ b/scripts/util/String.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 using Godot;
 
 namespace Util;
@@ -70,5 +71,17 @@ public class String
         }
 
         return formatted.TrimSuffix(pad) + decimals;
+    }
+
+    public static string SanitizeZalgo(string input, int limit = 3)
+    {
+        var zalgoSpamRegex = new Regex("([\\p{M}]){" + (limit + 1) + ",}");
+
+        return zalgoSpamRegex.Replace(input, "$1");
+    }
+
+    public static string SanitizeBBCode(string input)
+    {
+        return input.Replace("[", "[lb]");
     }
 }


### PR DESCRIPTION
Diacritics are capped at 3 per char to allow some freedom of expression, huge amounts could previously result in an engine crash