### PR TITLE
Fix: Add RHM to map import dialog filter

### DIFF
--- a/scenes/main_menu.tscn
+++ b/scenes/main_menu.tscn
@@ -803,7 +803,7 @@ theme = SubResource("Theme_nlclj")
 ok_button_text = "Open"
 file_mode = 1
 access = 2
-filters = PackedStringArray("*.sspm", "*.phxm", "*.txt")
+filters = PackedStringArray("*.sspm", "*.phxm", "*.txt", "*.rhm")
 use_native_dialog = true
 script = ExtResource("2_yxnar")
 


### PR DESCRIPTION
## Summary

Adds `.rhm` to the map import dialog filter so RHM files appear without selecting **All Files**.

RHM parsing is already supported by the client.