### PR TITLE
fix: separate score loading from Setup() to a separate function

### DIFF
--- a/scripts/ui/menu/play/MapInfoContainer.cs
+++ b/scripts/ui/menu/play/MapInfoContainer.cs
@@ -425,8 +425,19 @@ public partial class MapInfoContainer : Panel, ISkinnable
 
         Lobby.SetStartFrom(0);
 
-        preview.Setup(map, true);
+        LoadLeaderboard(map);
 
+        preview.Setup(map, true);
+    }
+
+    public void Refresh()
+    {
+        Setup(Map);
+        LoadLeaderboard(Map);
+    }
+
+    public void LoadLeaderboard(Map map)
+    {
         // Leaderboard
 
         Leaderboard = new();
@@ -454,11 +465,6 @@ public partial class MapInfoContainer : Panel, ISkinnable
 
             panel.Button.Pressed += () => { toggleLeaderboard(false); };
         }
-    }
-
-    public void Refresh()
-    {
-        Setup(Map);
     }
 
     public Tween Transition(bool show)


### PR DESCRIPTION
Setup() had if `(Name == map.Name) { return; }` which prevented the Setup() call in Refresh() to actually load the scores, fixed by moving the score loading to a separate function and then calling it both in Setup() and Refresh(). This pr addresses #42 