### PR TITLE
feat: Normalize Scoring

### DIFF
--- a/scripts/game/Attempt.cs
+++ b/scripts/game/Attempt.cs
@@ -36,7 +36,9 @@ public partial class Attempt : RefCounted
     public uint Hits = 0;
     public uint Misses = 0;
     public uint Sum = 0;
-    public uint Score = 0;
+    public double Score = 0;
+    public double UnitHitScore = 0;
+    public uint NoteWeight;
     public uint Combo = 0;
     public uint ComboMultiplier = 1;
     public uint ComboMultiplierProgress = 0;
@@ -82,6 +84,13 @@ public partial class Attempt : RefCounted
         Objects[typeof(Note)] = [.. map.Notes];
         HitsInfo = IsReplay ? Replays[0].Notes : new float[Map.Notes.Length];
 
+        for (uint i = 1; i <= 7; i++)
+        {
+            NoteWeight += ComboMultiplierIncrement * i;
+        }
+
+        NoteWeight += ((uint)Map.Notes.Length - ComboMultiplierIncrement * 7) * 8;
+
         if (Modifiers.Count >= 1)
         {
             foreach (Modifier modifier in Modifiers)
@@ -89,6 +98,8 @@ public partial class Attempt : RefCounted
                 ModsMultiplier += modifier.ScoreMultiplier - 1;
             }
         }
+
+        UnitHitScore = 1000000f * ModsMultiplier * ((Speed - 1) / 2.5 + 1) / NoteWeight;
 
         if (IsReplay)
         {

--- a/scripts/game/Attempt.cs
+++ b/scripts/game/Attempt.cs
@@ -43,6 +43,7 @@ public partial class Attempt : RefCounted
     public uint ComboMultiplier = 1;
     public uint ComboMultiplierProgress = 0;
     public uint ComboMultiplierIncrement = 0;
+    public uint MaxComboMultiplier = 0;
     public double ModsMultiplier = 1;
     public float[] HitsInfo = [];
     public Color LastHitColour = new();
@@ -77,19 +78,20 @@ public partial class Attempt : RefCounted
         Length = Math.Max(1000 * (SoundManager.Song?.Stream?.GetLength() ?? 0), Map.Length + 1000);
         Players = players ?? [];
         Progress = Speed * -1000 - Settings.ApproachTime * 1000 + StartFrom;
-        ComboMultiplierIncrement = Math.Max(2, (uint)Map.Notes.Length / 200);
+        ComboMultiplierIncrement = Map.Notes.Length <= 8 ? 1 : Math.Max(2, (uint)Map.Notes.Length / 200);
         CameraMode = cameraMode;
         Modifiers = mods;
         HasHealthModifier = Modifiers.Any(mod => mod is IHealthModifier);
         Objects[typeof(Note)] = [.. map.Notes];
         HitsInfo = IsReplay ? Replays[0].Notes : new float[Map.Notes.Length];
+        MaxComboMultiplier = (uint)Math.Clamp(Math.Floor((double)Map.Notes.Length / ComboMultiplierIncrement), 1, 7);
 
-        for (uint i = 1; i <= 7; i++)
+        for (uint i = 1; i <= MaxComboMultiplier; i++)
         {
             NoteWeight += ComboMultiplierIncrement * i;
         }
 
-        NoteWeight += ((uint)Map.Notes.Length - ComboMultiplierIncrement * 7) * 8;
+        NoteWeight += ((uint)Map.Notes.Length - ComboMultiplierIncrement * MaxComboMultiplier) * (MaxComboMultiplier + 1);
 
         if (Modifiers.Count >= 1)
         {

--- a/scripts/game/Attempt.cs
+++ b/scripts/game/Attempt.cs
@@ -43,7 +43,6 @@ public partial class Attempt : RefCounted
     public uint ComboMultiplier = 1;
     public uint ComboMultiplierProgress = 0;
     public uint ComboMultiplierIncrement = 0;
-    public uint MaxComboMultiplier = 0;
     public double ModsMultiplier = 1;
     public float[] HitsInfo = [];
     public Color LastHitColour = new();
@@ -78,20 +77,21 @@ public partial class Attempt : RefCounted
         Length = Math.Max(1000 * (SoundManager.Song?.Stream?.GetLength() ?? 0), Map.Length + 1000);
         Players = players ?? [];
         Progress = Speed * -1000 - Settings.ApproachTime * 1000 + StartFrom;
-        ComboMultiplierIncrement = Map.Notes.Length <= 8 ? 1 : Math.Max(2, (uint)Map.Notes.Length / 200);
+        ComboMultiplierIncrement = Math.Max(2, (uint)Map.Notes.Length / 200);
         CameraMode = cameraMode;
         Modifiers = mods;
         HasHealthModifier = Modifiers.Any(mod => mod is IHealthModifier);
         Objects[typeof(Note)] = [.. map.Notes];
         HitsInfo = IsReplay ? Replays[0].Notes : new float[Map.Notes.Length];
-        MaxComboMultiplier = (uint)Math.Clamp(Math.Floor((double)Map.Notes.Length / ComboMultiplierIncrement), 1, 7);
 
-        for (uint i = 1; i <= MaxComboMultiplier; i++)
+        uint noteWeightIterations = (uint)Math.Clamp(Math.Floor((double)Map.Notes.Length / ComboMultiplierIncrement), 1, 7);
+
+        for (uint i = 1; i <= noteWeightIterations; i++)
         {
-            NoteWeight += ComboMultiplierIncrement * i;
+            NoteWeight += Math.Min(ComboMultiplierIncrement, (uint)Map.Notes.Length) * i;
         }
 
-        NoteWeight += ((uint)Map.Notes.Length - ComboMultiplierIncrement * MaxComboMultiplier) * (MaxComboMultiplier + 1);
+        NoteWeight += ((uint)Map.Notes.Length - Math.Min(ComboMultiplierIncrement, (uint)Map.Notes.Length) * noteWeightIterations) * (noteWeightIterations + 1);
 
         if (Modifiers.Count >= 1)
         {

--- a/scripts/game/Attempt.cs
+++ b/scripts/game/Attempt.cs
@@ -85,12 +85,7 @@ public partial class Attempt : RefCounted
         HitsInfo = IsReplay ? Replays[0].Notes : new float[Map.Notes.Length];
 
         uint noteWeightIterations = (uint)Math.Clamp(Math.Floor((double)Map.Notes.Length / ComboMultiplierIncrement), 1, 7);
-
-        for (uint i = 1; i <= noteWeightIterations; i++)
-        {
-            NoteWeight += Math.Min(ComboMultiplierIncrement, (uint)Map.Notes.Length) * i;
-        }
-
+        NoteWeight += Math.Min(ComboMultiplierIncrement, (uint)Map.Notes.Length) * (1 + noteWeightIterations) * noteWeightIterations / 2;
         NoteWeight += ((uint)Map.Notes.Length - Math.Min(ComboMultiplierIncrement, (uint)Map.Notes.Length) * noteWeightIterations) * (noteWeightIterations + 1);
 
         if (Modifiers.Count >= 1)

--- a/scripts/game/Attempt.cs
+++ b/scripts/game/Attempt.cs
@@ -82,6 +82,14 @@ public partial class Attempt : RefCounted
         Objects[typeof(Note)] = [.. map.Notes];
         HitsInfo = IsReplay ? Replays[0].Notes : new float[Map.Notes.Length];
 
+        if (Modifiers.Count >= 1)
+        {
+            foreach (Modifier modifier in Modifiers)
+            {
+                ModsMultiplier += modifier.ScoreMultiplier - 1;
+            }
+        }
+
         if (IsReplay)
         {
             foreach (var replay in Replays)

--- a/scripts/game/Runner.cs
+++ b/scripts/game/Runner.cs
@@ -410,13 +410,13 @@ public partial class Runner : Node3D
 
                 Leaderboard leaderboard = new(Attempt.Map.Name, $"{Constants.USER_FOLDER}/pbs/{Attempt.Map.Name}");
 
-                leaderboard.Add(new(Attempt.ID, "You", Attempt.Qualifies, Attempt.Score, Attempt.Accuracy, Time.GetUnixTimeFromSystem(), Attempt.Progress, Attempt.Map.Length, Speed, mods));
+                leaderboard.Add(new(Attempt.ID, "You", Attempt.Qualifies, (ulong)Math.Round(Attempt.Score), Attempt.Accuracy, Time.GetUnixTimeFromSystem(), Attempt.Progress, Attempt.Map.Length, Speed, mods));
                 leaderboard.Save();
 
                 if (Attempt.Qualifies)
                 {
                     Stats.Instance.Passes++;
-                    Stats.Instance.TotalScore += Attempt.Score;
+                    Stats.Instance.TotalScore += (ulong)Math.Round(Attempt.Score);
 
                     if (Attempt.Accuracy == 100)
                     {
@@ -425,7 +425,7 @@ public partial class Runner : Node3D
 
                     if (Attempt.Score > Stats.Instance.HighestScore)
                     {
-                        Stats.Instance.HighestScore = Attempt.Score;
+                        Stats.Instance.HighestScore = (ulong)Math.Round(Attempt.Score);
                     }
 
                     Stats.Instance.AverageAccuracy = (Stats.Instance.AverageAccuracy + Attempt.Accuracy) / Stats.Instance.Passes;
@@ -445,7 +445,7 @@ public partial class Runner : Node3D
     {
         float lateness = Attempt.IsReplay ? Attempt.HitsInfo[noteIndex] : (float)(((int)Attempt.Progress - Attempt.Map.Notes[noteIndex].Millisecond) / Speed);
         float factor = 1 - Math.Max(0, lateness - 25) / 150f;
-        uint hitScore = (uint)(100 * Attempt.ComboMultiplier * Attempt.ModsMultiplier * factor * ((Speed - 1) / 2.5 + 1));
+        double hitScore = Attempt.UnitHitScore * Attempt.ComboMultiplier * factor;
 
         switch (hitResult)
         {

--- a/scripts/game/ui/PanelLeft.cs
+++ b/scripts/game/ui/PanelLeft.cs
@@ -56,7 +56,7 @@ public partial class PanelLeft : UIComponent
 
     public void OnStatsUpdated(Attempt attempt)
     {
-        score.Text = Util.String.PadMagnitude(attempt.Score.ToString());
+        score.Text = Util.String.PadMagnitude(Math.Round(attempt.Score).ToString());
         multiplier.Text = $"{attempt.ComboMultiplier}x";
         altCombo.Text = $"{attempt.Combo}";
 

--- a/scripts/scenes/Results.cs
+++ b/scripts/scenes/Results.cs
@@ -35,7 +35,7 @@ public partial class Results : BaseScene
         holder.GetNode<Label>("Difficulty").Text = attempt.Map.DifficultyName;
         holder.GetNode<Label>("Mappers").Text = $"by {attempt.Map.PrettyMappers}";
         holder.GetNode<Label>("Accuracy").Text = $"{attempt.Accuracy:F2}%";
-        holder.GetNode<Label>("Score").Text = $"{Util.String.PadMagnitude(attempt.Score.ToString())}";
+        holder.GetNode<Label>("Score").Text = $"{Util.String.PadMagnitude(Math.Round(attempt.Score).ToString())}";
         holder.GetNode<Label>("Hits").Text = $"{Util.String.PadMagnitude(attempt.Hits.ToString())} / {Util.String.PadMagnitude(attempt.Sum.ToString())}";
         holder.GetNode<Label>("Status").Text = attempt.IsReplay ? attempt.Replays[0].Status : attempt.Alive ? (attempt.Qualifies ? "PASSED" : "DISQUALIFIED") : "FAILED";
         holder.GetNode<Label>("Speed").Text = $"{attempt.Speed:F2}x";


### PR DESCRIPTION
Score is capped to 1 milion for all levels.  
Modifiers and speed modifiers are applied to the max score making it higher or lower.  

I also had to fix Attempt.ModsMultiplier since it was not being assigned and would always be equal to 1 no matter what.