### PR TITLE
fix: grid space not being transparent + small touchups to replay UI

### DIFF
--- a/prefabs/spaces/grid.tscn
+++ b/prefabs/spaces/grid.tscn
@@ -27,15 +27,6 @@ point_size = 23.8
 material = SubResource("StandardMaterial3D_n0yhb")
 size = Vector2(120, 120)
 
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_31ska"]
-shading_mode = 0
-albedo_color = Color(0, 0, 0, 1)
-
-[sub_resource type="BoxMesh" id="BoxMesh_ytxqq"]
-material = SubResource("StandardMaterial3D_31ska")
-flip_faces = true
-size = Vector3(120, 21, 120)
-
 [node name="Grid" type="Node3D" unique_id=2134769153]
 script = ExtResource("1_wac2s")
 
@@ -49,9 +40,6 @@ mesh = SubResource("PlaneMesh_yclqf")
 [node name="Top" type="MeshInstance3D" parent="." unique_id=1325224979]
 transform = Transform3D(1, 0, 0, 0, -1, 8.74228e-08, 0, -8.74228e-08, -1, 0, 10, 0)
 mesh = SubResource("PlaneMesh_yclqf")
-
-[node name="Shell" type="MeshInstance3D" parent="." unique_id=1123784198]
-mesh = SubResource("BoxMesh_ytxqq")
 
 [node name="Camera3D" type="Camera3D" parent="." unique_id=1660955999]
 fov = 70.0

--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -679,7 +679,6 @@ font = ExtResource("21_05nbr")
 transform = Transform3D(1, 0, 0, 0, 0.965926, 0.258819, 0, -0.258819, 0.965926, 0, -8.5, -10)
 visible = false
 modulate = Color(1, 1, 1, 0.376471)
-pixel_size = 0.015
 double_sided = false
 no_depth_test = true
 texture = ExtResource("34_8ool0")

--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -836,7 +836,7 @@ layout_mode = 1
 anchors_preset = -1
 offset_right = 40.0
 grow_vertical = 0
-text = "Press F2 to hide replay UI, F3 to hide orthogonal camera, F to toggle note fade, P to toggle note pushback"
+text = "Press F2 to hide replay UI, F3 to hide orthogonal camera, F to toggle fade out, P to toggle note pushback"
 label_settings = SubResource("LabelSettings_a70tm")
 
 [node name="Time" type="Label" parent="ReplayViewer" unique_id=1277133470]

--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -836,7 +836,7 @@ layout_mode = 1
 anchors_preset = -1
 offset_right = 40.0
 grow_vertical = 0
-text = "Press F2 to hide replay UI, F3 to hide orthogonal camera, F to toggle fade out, P to toggle note pushback"
+text = "Press F2 to hide replay UI, F3 to hide orthogonal camera, F to toggle note fade out, P to toggle note pushback"
 label_settings = SubResource("LabelSettings_a70tm")
 
 [node name="Time" type="Label" parent="ReplayViewer" unique_id=1277133470]

--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -679,6 +679,7 @@ font = ExtResource("21_05nbr")
 transform = Transform3D(1, 0, 0, 0, 0.965926, 0.258819, 0, -0.258819, 0.965926, 0, -8.5, -10)
 visible = false
 modulate = Color(1, 1, 1, 0.376471)
+pixel_size = 0.015
 double_sided = false
 no_depth_test = true
 texture = ExtResource("34_8ool0")
@@ -793,9 +794,9 @@ z_index = -1
 z_as_relative = false
 layout_mode = 1
 offset_left = -5.0
-offset_top = -283.0
+offset_top = -310.0
 offset_right = 259.0
-offset_bottom = -19.0
+offset_bottom = -46.0
 offset_transform_enabled = true
 offset_transform_pivot_ratio = Vector2(1, 1)
 offset_transform_visual_only = false
@@ -809,12 +810,13 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -128.0
-offset_top = -128.0
-offset_right = 128.0
-offset_bottom = 128.0
+offset_left = -152.0
+offset_top = -152.0
+offset_right = 104.0
+offset_bottom = 104.0
 grow_horizontal = 2
 grow_vertical = 2
+scale = Vector2(1.2, 1.2)
 offset_transform_enabled = true
 
 [node name="SubViewport" type="SubViewport" parent="ReplayViewer/OrthogonalPanel/OrthogonalCamera" unique_id=559747074]
@@ -828,14 +830,14 @@ render_target_update_mode = 4
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0.44182658)
 top_level = true
 projection = 1
-size = 3.1727066
+size = 4.5
 
 [node name="Tip" type="Label" parent="ReplayViewer" unique_id=919285545]
 layout_mode = 1
 anchors_preset = -1
 offset_right = 40.0
 grow_vertical = 0
-text = "Press F2 to hide replay UI, F3 to hide orthogonal camera"
+text = "Press F2 to hide replay UI, F3 to hide orthogonal camera, F to toggle note fade, P to toggle note pushback"
 label_settings = SubResource("LabelSettings_a70tm")
 
 [node name="Time" type="Label" parent="ReplayViewer" unique_id=1277133470]


### PR DESCRIPTION
offgrid doesn't get cutoff anymore, deleted shell inside grid space, added text in the replay ui to clarify u can use F and P to toggle note fade out and note pushback 