### PR TITLE
fix: set Invariant culture in SliderLineEdit's placeholder

### DIFF
--- a/scripts/ui/SettingsMenu.cs
+++ b/scripts/ui/SettingsMenu.cs
@@ -319,7 +319,7 @@ public partial class SettingsMenu : ColorRect
         if (setting is SettingsItem<double>) { placeholder = (setting as SettingsItem<double>).DefaultValue; }
         else if (setting is SettingsItem<int>) { placeholder = (setting as SettingsItem<int>).DefaultValue; }
 
-        lineEdit.PlaceholderText = placeholder.ToString("F4");
+        lineEdit.PlaceholderText = placeholder.ToString("F4", System.Globalization.CultureInfo.InvariantCulture);
         slider.Step = setting.Slider.Step;
         slider.MinValue = setting.Slider.MinValue;
         slider.MaxValue = setting.Slider.MaxValue;


### PR DESCRIPTION
I saw invariant culture used everywhere so I set it to SliderLineEdit's placeholder too since it was missing.
Now defaults work correctly on locales different then US.

Fixes #137 